### PR TITLE
Remove component initializer requirement for Ruby 2.7+

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ end
 ```
 
 ### Previewing Components
-`ActionView::Component::Preview`s provide a way to see how components look by visiting a special URL that renders them.
+`ActionView::Component::Preview` provides a way to see how components look by visiting a special URL that renders them.
 In the previous example, the preview class for `TestComponent` would be called `TestComponentPreview` and located in `test/components/previews/test_component_preview.rb`.
 To see the preview of the component with a given title, implement a method that renders the component.
 You can define as many examples as you want:

--- a/lib/action_view/component/base.rb
+++ b/lib/action_view/component/base.rb
@@ -115,21 +115,21 @@ module ActionView
         end
 
         def source_location
-          # Require #initialize to be defined so that we can use
-          # method#source_location to look up the file name
-          # of the component.
-          #
-          # If we were able to only support Ruby 2.7+,
-          # We could just use Module#const_source_location,
-          # rendering this unnecessary.
-          raise NotImplementedError.new("#{self} must implement #initialize.") unless has_initializer?
+          if RUBY_VERSION < "2.7"
+            # When using a version of Ruby < 2.7, require #initialize
+            # to be defined so that we can use method#source_location
+            # to look up the file name of the component.'
+            raise NotImplementedError.new("#{self} must implement #initialize.") unless has_initializer?
 
-          instance_method(:initialize).source_location[0]
+            return instance_method(:initialize).source_location[0]
+          end
+
+          Module.const_source_location(self.name)[0]
         end
 
         def eager_load!
           self.descendants.each do |descendant|
-            descendant.compile if descendant.has_initializer?
+            descendant.compile if RUBY_VERSION >= "2.7" || descendant.has_initializer?
           end
         end
 

--- a/test/action_view/component_test.rb
+++ b/test/action_view/component_test.rb
@@ -232,6 +232,18 @@ class ActionView::ComponentTest < ActionView::Component::TestCase
     assert_html_matches "<span>The Awesome post component!</span>", render_inline(post).to_html
   end
 
+  def test_no_initializer
+    if RUBY_VERSION < "2.7"
+      exception = assert_raises NotImplementedError do
+        render_inline(NoInitializerComponent)
+      end
+
+      assert_includes exception.message, "must implement #initialize"
+    else
+      assert_html_matches "Hello, world!", render_inline(NoInitializerComponent).text
+    end
+  end
+
   private
 
   def modify_file(file, content)

--- a/test/app/components/no_initializer_component.html.erb
+++ b/test/app/components/no_initializer_component.html.erb
@@ -1,0 +1,1 @@
+<div>Hello, world!</div>

--- a/test/app/components/no_initializer_component.rb
+++ b/test/app/components/no_initializer_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class NoInitializerComponent < ActionView::Component::Base
+end

--- a/test/invalid/invalid_components_test.rb
+++ b/test/invalid/invalid_components_test.rb
@@ -1,20 +1,11 @@
 # frozen_string_literal: true
 
 require "invalid_components_test_helper"
-require "invalid/missing_initializer_component"
 require "invalid/missing_template_component"
 require "invalid/too_many_sidecar_files_component"
 require "invalid/too_many_sidecar_files_for_variant_component"
 
 class ActionView::InvalidComponentTest < ActionView::Component::TestCase
-  def test_raises_error_when_initializer_is_not_defined
-    exception = assert_raises NotImplementedError do
-      render_inline(MissingInitializerComponent)
-    end
-
-    assert_includes exception.message, "must implement #initialize"
-  end
-
   def test_raises_error_when_sidecar_template_is_missing
     exception = assert_raises NotImplementedError do
       render_inline(MissingTemplateComponent)

--- a/test/invalid/missing_initializer_component.rb
+++ b/test/invalid/missing_initializer_component.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-class MissingInitializerComponent < ActionView::Component::Base
-end


### PR DESCRIPTION
### Motivation

As discussed in github#93, Ruby 2.7 introduces [`#const_source_location`](https://ruby-doc.org/core-2.7.0/Module.html#method-i-const_source_location) to find the location of constants. This means that we no longer have to find the location of components through the location of their `#initialize` method, and we can remove the initializer requirement for Ruby 2.7+.

### Changes

* Use `#const_source_location` in `ActionView::Component::Base::source_location`, when it's available. 
* Move the initializer-less component test out of invalid, and in to a proper component test. Test it still throws the error for Rubies < 2.7.
* Change eager-loading logic for Ruby 2.7+

### Todo

- [ ] Test eager loading change
- [ ] Update CI to test Ruby 2.7. Unfortunately, 2.7 is not yet supported by setup-ruby (actions/setup-ruby#45).